### PR TITLE
refactor: integrate react-hook-form with profile dialog form

### DIFF
--- a/src/components/Breadcurmb/index.tsx
+++ b/src/components/Breadcurmb/index.tsx
@@ -20,10 +20,12 @@ const Breadcrumb: React.FC<BreadcrumbProps> = ({ breadcrumbs }) => {
           const isMatch = matchPath(breadcrumb.href, location.pathname) || location.pathname.startsWith(breadcrumb.href);
           return (
             isMatch && (
-              <BreadcrumbItem key={breadcrumb.href}>
+              <div className="flex" key={breadcrumb.href}>
                 <BreadcrumbSeparator />
-                <BreadcrumbLink href={breadcrumb.href}>{breadcrumb.label}</BreadcrumbLink>
-              </BreadcrumbItem>
+                <BreadcrumbItem>
+                  <BreadcrumbLink href={breadcrumb.href}>{breadcrumb.label}</BreadcrumbLink>
+                </BreadcrumbItem>
+              </div>
             )
           );
         })}

--- a/src/components/FormField/index.tsx
+++ b/src/components/FormField/index.tsx
@@ -1,25 +1,35 @@
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Control, FieldPath, FieldValues } from "react-hook-form";
 
-interface FormFieldProps {
-  id: string;
+import { Input } from "@/components/ui/input";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+
+interface FormFieldItemProps<T extends FieldValues> {
+  fieldControl: Control<T>;
+  name: FieldPath<T>;
   label: string;
-  value?: string;
-  type?: FormType;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
 }
 
-type FormType = "text" | "number" | "email" | "file";
-
-const FormField: React.FC<FormFieldProps> = ({ id, label, value = "", type = "text", onChange }) => {
+export const FormFieldItem = <T extends FieldValues>({ fieldControl, name, label, placeholder }: FormFieldItemProps<T>) => {
   return (
-    <div className="flex-1 flex flex-col items-start gap-1">
-      <Label htmlFor={id} className="text-right text-sm">
-        {label}
-      </Label>
-      <Input id={id} type={type} value={value} className="py-2" onChange={onChange} />
-    </div>
+    <FormField
+      control={fieldControl}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="w-full">
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <Input
+              placeholder={placeholder}
+              {...field}
+              onChange={e => {
+                field.onChange(e);
+              }}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   );
 };
-
-export default FormField;

--- a/src/components/Header/ProfileDialog.tsx
+++ b/src/components/Header/ProfileDialog.tsx
@@ -1,16 +1,17 @@
-import { ReactNode, useRef, useState } from "react";
+import { ReactNode } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 
-import Avatar from "@/components/Avatar";
-import AppFormField from "@/components/FormField";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import Avatar from "@/components/Avatar";
+import { FormFieldItem } from "@/components/FormField";
 import { abbreviateName, ellipticalString } from "@/utils/formatters";
-import { Profile } from "@/types/profile";
+import { Form } from "../ui/form";
 
-const data = {
+const userProfileData = {
   profileId: "123e4567-e89b-12d3-a456-426614174000",
   orgId: "654e7890-f12c-34a5-b678-921345678901",
   roleId: "987e6543-f21c-45d6-c789-234567890123",
@@ -18,40 +19,50 @@ const data = {
   supervisedBy: "111e2222-c33d-44b5-d678-123456789012",
   name: "John Doe",
   email: "johndoe@example.com",
-  phone: "+61 400 123 456",
+  phone: "+61 450123456",
   avatarLink: "https://github.com/davidmiller.png",
   isActive: true,
   createdAt: "2023-12-01T12:34:56Z",
   updatedAt: "2023-12-10T15:20:30Z"
 };
 
+const userProfileInfoFormSchema = z.object({
+  avatarLink: z.string().optional(),
+  name: z
+    .string()
+    .min(2, {
+      message: "User name must be at least 2 characters."
+    })
+    .max(50, {
+      message: "User name must not exceed 50 characters." // Restrains max length
+    }),
+  email: z.string().email({
+    message: "Invalid email format."
+  }),
+  phone: z
+    .string()
+    .optional()
+    .refine(value => !value || /^\+61 45\d{7}$/.test(value), {
+      message: "Phone number must start with +61 45 and be followed by 7 digits."
+    })
+});
+
+const avatarAlt = "@InnovateFoundation";
+
 const ProfileDialog: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [formData, setFormData] = useState<Profile>({
-    name: data.name ?? "",
-    email: data.email ?? "",
-    phone: data.phone ?? "",
-    avatarLink: data.avatarLink ?? ""
-  });
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const avatarAlt = "@InnovateFoundation";
-
-  const handleInputChange = (field: string, value: string) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
-  };
-
-  const handleUploadChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files[0]) {
-      setFormData(prev => ({
-        ...prev,
-        // @ts-expect-error: 'files' might be null, but it's handled elsewhere
-        profileAvatarLink: URL.createObjectURL(e.target.files[0])
-      }));
+  const userProfileInfoForm = useForm<z.infer<typeof userProfileInfoFormSchema>>({
+    resolver: zodResolver(userProfileInfoFormSchema),
+    mode: "onChange",
+    defaultValues: {
+      avatarLink: userProfileData.avatarLink,
+      name: userProfileData.name,
+      email: userProfileData.email,
+      phone: userProfileData.phone
     }
-    // TODO: Upload the image to the server
-  };
+  });
 
-  const handleSubmit = () => {
-    console.log("Form Data Submitted: ", formData);
+  const handleUserProfileInfoSubmit = (data: z.infer<typeof userProfileInfoFormSchema>) => {
+    console.log("User Profile Info Submitted: ", data);
     // TODO: Perform actions such as sending the data to the server
   };
 
@@ -62,9 +73,9 @@ const ProfileDialog: React.FC<{ children: ReactNode }> = ({ children }) => {
         <div className="h-14 bg-accent">
           <Avatar
             className="absolute top-6 left-8"
-            avatarLink={formData.avatarLink ?? ""}
+            avatarLink={userProfileInfoForm.watch("avatarLink") ?? ""}
             avatarAlt={avatarAlt}
-            avatarPlaceholder={abbreviateName(formData.name!)}
+            avatarPlaceholder={abbreviateName(userProfileInfoForm.watch("name"))}
             size={14}
             outline={true}
           />
@@ -72,38 +83,22 @@ const ProfileDialog: React.FC<{ children: ReactNode }> = ({ children }) => {
         <div className="p-8 pt-6">
           <DialogHeader>
             <div className="flex-col flex items-start">
-              <DialogTitle>{ellipticalString(formData.name!, 20)}</DialogTitle>
-              <DialogDescription>{ellipticalString(formData.email!, 20)}</DialogDescription>
+              <DialogTitle>{ellipticalString(userProfileInfoForm.watch("name"), 20)}</DialogTitle>
+              <DialogDescription>{ellipticalString(userProfileInfoForm.watch("email"), 20)}</DialogDescription>
             </div>
           </DialogHeader>
           <Separator className="my-4" />
           <div className="grid gap-4 ">
-            <AppFormField id={"name"} label={"Name"} value={formData.name!} onChange={e => handleInputChange("profileName", e.target.value)} />
-            <AppFormField
-              id={"email"}
-              type={"email"}
-              label={"Email"}
-              value={formData.email!}
-              onChange={e => handleInputChange("profileEmail", e.target.value)}
-            />
-            <AppFormField id={"phone"} label={"Phone"} value={formData.phone!} onChange={e => handleInputChange("profilePhone", e.target.value)} />
-
-            <div className="flex flex-col items-start gap-1">
-              <Label htmlFor="profile-photo" className="text-right text-sm">
-                Profile photo
-              </Label>
-              <div className="flex gap-4 items-center">
-                <Avatar avatarLink={formData.avatarLink!} avatarAlt={avatarAlt} avatarPlaceholder={abbreviateName(formData.name!)} />
-                <Input id="profile-photo" type="file" onChange={handleUploadChange} ref={fileInputRef} />
-              </div>
-            </div>
+            <Form {...userProfileInfoForm}>
+              <FormFieldItem fieldControl={userProfileInfoForm.control} name="name" label="Name" placeholder="John Doe" />
+              <FormFieldItem fieldControl={userProfileInfoForm.control} name="email" label="Email" placeholder="johndoe@example.com" />
+              <FormFieldItem fieldControl={userProfileInfoForm.control} name="phone" label="Phone" placeholder="+61 400 123 456" />
+            </Form>
           </div>
           <Separator className="my-4" />
           <DialogFooter>
             <div className="flex gap-4 justify-end">
-              <Button type="submit" onClick={handleSubmit}>
-                Save changes
-              </Button>
+              <Button onClick={userProfileInfoForm.handleSubmit(handleUserProfileInfoSubmit)}>Save changes</Button>
             </div>
           </DialogFooter>
         </div>

--- a/src/pages/Organisation/OrganisationProfile.tsx
+++ b/src/pages/Organisation/OrganisationProfile.tsx
@@ -1,12 +1,12 @@
-import { Control, FieldPath, FieldValues, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
-import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Form } from "@/components/ui/form";
 import Avatar from "@/components/Avatar";
 import FormWrapper from "@/components/FormWrapper.tsx";
-import { Badge } from "@/components/ui/badge";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { FormFieldItem } from "@/components/FormField";
 
 const orgProfileDetail = {
   orgName: "JR Academy",
@@ -184,34 +184,3 @@ const OrganisationProfile = () => {
 };
 
 export default OrganisationProfile;
-
-interface FormFieldItemProps<T extends FieldValues> {
-  fieldControl: Control<T>;
-  name: FieldPath<T>;
-  label: string;
-  placeholder: string;
-}
-
-export const FormFieldItem = <T extends FieldValues>({ fieldControl, name, label, placeholder }: FormFieldItemProps<T>) => {
-  return (
-    <FormField
-      control={fieldControl}
-      name={name}
-      render={({ field }) => (
-        <FormItem className="w-full">
-          <FormLabel>{label}</FormLabel>
-          <FormControl>
-            <Input
-              placeholder={placeholder}
-              {...field}
-              onChange={e => {
-                field.onChange(e);
-              }}
-            />
-          </FormControl>
-          <FormMessage />
-        </FormItem>
-      )}
-    />
-  );
-};


### PR DESCRIPTION
This PR introduces the integration of react-hook-form into the existing user profile editing dialog form, enhancing its structure and functionality. Additionally, it resolves a bug caused by the BreadcrumbSeparator component.

**Key Changes:**

- Created a reusable FormField component that integrates with react-hook-form, streamlining form validation and handling across the application.
- Updated the original ShadCN-based form field UI in the user profile editing dialog to use the new FormField component for consistency and better maintainability.
- Fixed the issue related to incorrect nesting caused by the BreadcrumbSeparator component.

**Test Method:**

- Verified the user profile editing workflow in the browser to ensure all functionalities are working as expected.

**Related Ticket**

[JIRA Ticket: IF-179](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-179)
