### PR TITLE
fix: use truncate max-w-num to eclipse string

### DIFF
--- a/src/components/Header/ProfileDialog.tsx
+++ b/src/components/Header/ProfileDialog.tsx
@@ -8,7 +8,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Separator } from "@/components/ui/separator";
 import Avatar from "@/components/Avatar";
 import { FormFieldItem } from "@/components/FormField";
-import { abbreviateName, ellipticalString } from "@/utils/formatters";
+import { abbreviateName } from "@/utils/formatters";
 import { Form } from "../ui/form";
 
 const userProfileData = {
@@ -83,8 +83,8 @@ const ProfileDialog: React.FC<{ children: ReactNode }> = ({ children }) => {
         <div className="p-8 pt-6">
           <DialogHeader>
             <div className="flex-col flex items-start">
-              <DialogTitle>{ellipticalString(userProfileInfoForm.watch("name"), 20)}</DialogTitle>
-              <DialogDescription>{ellipticalString(userProfileInfoForm.watch("email"), 20)}</DialogDescription>
+              <DialogTitle className="truncate max-w-20">{userProfileInfoForm.watch("name")}</DialogTitle>
+              <DialogDescription className="truncate max-w-40">{userProfileInfoForm.watch("email")}</DialogDescription>
             </div>
           </DialogHeader>
           <Separator className="my-4" />

--- a/src/components/Header/SignInAvatar.tsx
+++ b/src/components/Header/SignInAvatar.tsx
@@ -1,4 +1,4 @@
-import { abbreviateName, ellipticalString } from "@/utils/formatters";
+import { abbreviateName } from "@/utils/formatters";
 import { ChevronDown, LogOut, User } from "lucide-react";
 import ProfileDialog from "@/components/Header/ProfileDialog";
 import Avatar from "../Avatar";
@@ -14,8 +14,8 @@ type avatarType = {
 const SignInAvatar: React.FC<avatarType> = ({ name, email, avatarLink }) => (
   <div className="flex gap-2 items-center">
     <div className="flex flex-col items-end gap-[2px]">
-      <p className="text-secondary font-bold text-sm leading-3">{ellipticalString(name, 16)}</p>
-      <p className="text-secondary text-[12px] leading-3">{ellipticalString(email, 24)}</p>
+      <p className="text-secondary font-bold text-sm leading-3 truncate max-w-20">{name}</p>
+      <p className="text-secondary text-[12px] leading-3 truncate max-w-40">{email}</p>
     </div>
     <HoverCard
       className="w-auto flex flex-col gap-2 p-2"

--- a/src/pages/Dashboard/Sidebar.tsx
+++ b/src/pages/Dashboard/Sidebar.tsx
@@ -18,7 +18,6 @@ import {
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useState } from "react";
 import Avatar from "@/components/Avatar";
-import { ellipticalString } from "@/utils/formatters";
 import { SidebarheaderAccess } from "./SidebarMenu";
 
 export interface SidebarProps {
@@ -56,8 +55,8 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarItemGroups, sidebarheader }) =
                       avatarPlaceholder={"AC"}
                     />
                     <div className="flex flex-col items-start gap-[2px]">
-                      <p className="text-primary font-bold text-sm leading-3">{ellipticalString("Acme Corporation", 16)}</p>
-                      <p className="text-primary text-[12px] leading-3">{ellipticalString("info@acmecorp.com", 24)}</p>
+                      <p className="text-primary font-bold text-sm leading-3 truncate max-w-20">{"Acme Corporation"}</p>
+                      <p className="text-primary text-[12px] leading-3 truncate max-w-40">{"info@acmecorp.com"}</p>
                     </div>
                   </div>
                 </Link>

--- a/src/pages/Organisation/orgColumns.tsx
+++ b/src/pages/Organisation/orgColumns.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import AppAvatar from "@/components/Avatar";
 import AppDropdown from "@/components/Dropdown";
-import { abbreviateName, ellipticalString, formatDateToDDMMYYYY } from "@/utils/formatters";
+import { abbreviateName, formatDateToDDMMYYYY } from "@/utils/formatters";
 import { Organisation } from "@/types";
 
 export const orgColumns: ColumnDef<Organisation>[] = [
@@ -47,7 +47,7 @@ export const orgColumns: ColumnDef<Organisation>[] = [
         }}
       >
         <AppAvatar avatarLink={row.original.logoUrl ?? ""} avatarAlt="@InnovateFuture" avatarPlaceholder={abbreviateName(row.getValue("orgName"))} size={7} />
-        <div className="ml-1 lowercase">{ellipticalString(row.getValue("orgName"), 15)}</div>
+        <div className="ml-1 lowercase truncate max-w-20">{row.getValue("orgName")}</div>
       </Button>
     ),
     enableColumnFilter: false
@@ -55,7 +55,7 @@ export const orgColumns: ColumnDef<Organisation>[] = [
   {
     accessorKey: "email",
     header: "Email",
-    cell: ({ row }) => <div className="lowercase">{ellipticalString(row.getValue("email"), 20)}</div>,
+    cell: ({ row }) => <div className="lowercase truncate max-w-40">{row.getValue("email")}</div>,
     enableColumnFilter: false
   },
   {

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { abbreviateName, ellipticalString } from "./formatters";
+import { abbreviateName } from "./formatters";
 import { formatDateToDDMMYYYY } from "./formatters";
 
 describe("abbreviateName function", () => {
@@ -19,27 +19,6 @@ describe("abbreviateName function", () => {
 
   it("should handle names with multiple spaces", () => {
     expect(abbreviateName("   John   Doe   ")).toBe("JD");
-  });
-});
-
-describe("ellipticalString", () => {
-  it("should truncate and add ellipsis when the sentence exceeds the digit limit", () => {
-    expect(ellipticalString("Hello World!", 5)).toBe("Hello...");
-  });
-
-  it("should return the full sentence if its length is less than or equal to the digit limit", () => {
-    expect(ellipticalString("Short", 10)).toBe("Short");
-    expect(ellipticalString("Exact", 5)).toBe("Exact");
-  });
-
-  it("should return an empty string if the sentence is empty or the digit limit is zero or less", () => {
-    expect(ellipticalString("", 5)).toBe("");
-    expect(ellipticalString("Non-empty", 0)).toBe("");
-    expect(ellipticalString("Non-empty", -5)).toBe("");
-  });
-
-  it("should handle leading and trailing spaces correctly", () => {
-    expect(ellipticalString("  Hello World!  ", 7)).toBe("Hello...");
   });
 });
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -10,12 +10,6 @@ export const abbreviateName = (name: string): string => {
   return abbreviation;
 };
 
-export const ellipticalString = (sentence: string, digit: number): string => {
-  if (!sentence || digit <= 0) return "";
-  if (sentence.length <= digit) return sentence;
-  return `${sentence.substring(0, digit).trim()}...`;
-};
-
 export const formatDateToDDMMYYYY = (isoDate: string): string => {
   const date = new Date(isoDate); // Convert ISO string to Date object
   const day = String(date.getDate()).padStart(2, "0"); // Get day and pad with leading zero


### PR DESCRIPTION
This PR simplifies the code by replacing the redundant eclipcal string function with the utility class truncate max-w-num.

**Key Changes:**

- Removed the eclipcal string function as it was redundant.
- Implemented the utility class truncate max-w-num for handling string truncation.

**Test Method:**

- Changes were manually tested in the browser to ensure the desired truncation behavior and responsiveness.

**Related Ticket**

[JIRA Ticket: IF-190](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-190)
