### PR TITLE
Refactor/if 219 expose child components

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,4 +1,5 @@
 import { Avatar as CNAvatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
 
 interface AvatarProps {
   avatarLink: string;
@@ -7,13 +8,25 @@ interface AvatarProps {
   size?: number;
   outline?: boolean;
   className?: string;
+  imageProps?: React.ComponentProps<typeof AvatarImage>;
+  fallbackProps?: React.ComponentProps<typeof AvatarFallback>;
 }
-const Avatar: React.FC<AvatarProps> = ({ avatarLink, avatarAlt, avatarPlaceholder, size = 10, outline = false, className = "" }) => {
+const Avatar: React.FC<AvatarProps> = ({
+  avatarLink,
+  avatarAlt,
+  avatarPlaceholder,
+  size = 10,
+  outline = false,
+  className,
+  imageProps = {},
+  fallbackProps = {},
+  ...props
+}) => {
   const avatarStyle = `w-${size} h-${size} ${outline && "outline outline-white"}`;
   return (
-    <CNAvatar className={`${avatarStyle} ${className}`.trim()}>
-      <AvatarImage src={avatarLink} alt={avatarAlt} />
-      <AvatarFallback>{avatarPlaceholder}</AvatarFallback>
+    <CNAvatar className={cn(avatarStyle, className)} {...props}>
+      <AvatarImage src={avatarLink} alt={avatarAlt} {...imageProps} />
+      <AvatarFallback {...fallbackProps}>{avatarPlaceholder}</AvatarFallback>
     </CNAvatar>
   );
 };

--- a/src/components/Breadcurmb/index.tsx
+++ b/src/components/Breadcurmb/index.tsx
@@ -1,8 +1,16 @@
 import { useMatches } from "react-router-dom";
 
 import { Breadcrumb as CNBreadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbSeparator } from "@/components/ui/breadcrumb";
+import { cn } from "@/lib/utils";
 
-const Breadcrumb = () => {
+interface BreadcrumbProps {
+  className?: string;
+  separatorProps?: React.ComponentProps<typeof BreadcrumbSeparator>;
+  itemProps?: React.ComponentProps<typeof BreadcrumbItem>;
+  linkProps?: React.ComponentProps<typeof BreadcrumbLink>;
+}
+
+const Breadcrumb: React.FC<BreadcrumbProps> = ({ className, itemProps = {}, linkProps = {}, separatorProps = {} }) => {
   const matches = useMatches();
   const breadcrumbs = matches
     .map(match => {
@@ -13,12 +21,14 @@ const Breadcrumb = () => {
     .filter(Boolean);
   return (
     <CNBreadcrumb>
-      <BreadcrumbList className="capitalize">
+      <BreadcrumbList className={cn("capitalize", className)}>
         {breadcrumbs.map(breadcrumb => (
           <div className="flex" key={breadcrumb!.href}>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink href={breadcrumb!.href}>{breadcrumb!.label}</BreadcrumbLink>
+            <BreadcrumbSeparator {...separatorProps} />
+            <BreadcrumbItem {...itemProps}>
+              <BreadcrumbLink {...linkProps} href={breadcrumb!.href}>
+                {breadcrumb!.label}
+              </BreadcrumbLink>
             </BreadcrumbItem>
           </div>
         ))}


### PR DESCRIPTION
This PR set two example to expose child components props to outer components props

**Key Changes:**

- Enhanced the Avatar component to expose className and other props for its child components (AvatarImage and AvatarFallback) to enable customization from parent components.
- Updated the Breadcrumb component to expose separatorProps, itemProps, and linkProps, allowing outer components to customize styles and behaviors for its child components.

**Test Method:**

- Verified by integrating the updated Avatar and Breadcrumb components in example scenarios to ensure proper rendering and customization.

**Related Ticket**

[JIRA Ticket: IF-219](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-219)
