### PR TITLE
feat: add enhanced Discord notifications workflow

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -12,23 +12,23 @@ jobs:
       - name: Discord notification
         if: github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: "https://discord.com/api/webhooks/xF1Ctgaci6HeOYjGnRYOmHLBRLWPn1WAXMtKe5c7bfC4r9MKssyE1rJZMZ_vuuMg92_Y"
         uses: Ilshidur/action-discord@master
         with:
           args: |
             {
-              "content": "${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}\n**Title:** ${{ github.event.pull_request.title }}\n**Author:** ${{ github.event.pull_request.user.login }}",
+              "content": "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}",
               "thread_id": "1330422313769893938"
             }
 
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: "https://discord.com/api/webhooks/xF1Ctgaci6HeOYjGnRYOmHLBRLWPn1WAXMtKe5c7bfC4r9MKssyE1rJZMZ_vuuMg92_Y"
         uses: Ilshidur/action-discord@master
         with:
           args: |
             {
-              "content": "🎉 PR Merged: ${{ github.event.pull_request.html_url }}\n**Title:** ${{ github.event.pull_request.title }}\n**Merged by:** ${{ github.event.pull_request.merged_by.login }}",
+              "content": "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}",
               "thread_id": "1330422313769893938"
             }

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -15,7 +15,11 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
-          args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
+          args: >
+            {
+              "content": "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}",
+              "thread_id": "1330422313769893938"
+            }
 
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
@@ -23,4 +27,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
-          args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"
+          args: >
+            {
+              "content": "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}",
+              "thread_id": "1330422313769893938"
+            }

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -1,0 +1,140 @@
+name: Enhanced Discord Notifications
+
+on:
+  pull_request:
+    types: [opened, reopened, closed, ready_for_review, synchronize]
+  push:
+    branches: [main, develop]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+  DISCORD_THREAD_ID: 1332133384075481098
+  SKIP_KEYWORD: '[skip notification]'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    concurrency:
+      group: notify-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Prepare PR Metadata
+        id: prepare
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number
+              });
+              return {
+                changed_files: pr.changed_files,
+                additions: pr.additions,
+                deletions: pr.deletions,
+                labels: pr.labels.map(label => label.name).join(', ') || 'None',
+                branch: pr.head.ref,
+                base: pr.base.ref
+              };
+            } catch (error) {
+              core.setFailed(`Failed to get PR data: ${error.message}`);
+              return {};
+            }
+
+      - name: PR Notification
+        if: |
+          github.event_name == 'pull_request' &&
+          !contains(github.event.pull_request.title, env.SKIP_KEYWORD) &&
+          !github.event.pull_request.draft
+        uses: Ilshidur/action-discord@master
+        with:
+          args: |
+            {
+              "embeds": [{
+                "title": "${{ github.event.pull_request.merged && '🚀 Merged PR' || '🔄 Updated PR' }}",
+                "color": ${{ github.event.pull_request.merged && '32768' || '5814783' }},
+                "fields": [
+                  {
+                    "name": "Title",
+                    "value": "[${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})",
+                    "inline": false
+                  },
+                  {
+                    "name": "Branch",
+                    "value": "`${{ fromJSON(steps.prepare.outputs.result).branch }} ➜ ${{ fromJSON(steps.prepare.outputs.result).base }}`",
+                    "inline": true
+                  },
+                  {
+                    "name": "Changes",
+                    "value": "📄 ${{ fromJSON(steps.prepare.outputs.result).changed_files }} files (+${{ fromJSON(steps.prepare.outputs.result).additions }}/-${{ fromJSON(steps.prepare.outputs.result).deletions }})",
+                    "inline": true
+                  },
+                  {
+                    "name": "Labels",
+                    "value": "${{ fromJSON(steps.prepare.outputs.result).labels }}",
+                    "inline": true
+                  }
+                ],
+                "footer": {
+                  "text": "By ${{ github.actor }} • ${{ github.event.pull_request.updated_at }}"
+                }
+              }],
+              "thread_id": "${{ env.DISCORD_THREAD_ID }}"
+            }
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+
+      - name: Push Notification
+        if: |
+          github.event_name == 'push' &&
+          !contains(github.event.head_commit.message, env.SKIP_KEYWORD)
+        uses: Ilshidur/action-discord@master
+        with:
+          args: |
+            {
+              "embeds": [{
+                "title": "📦 ${{ contains(github.ref, 'main') && 'Production' || 'Development' }} Update",
+                "color": ${{ contains(github.ref, 'main') && '16711680' || '32768' }},
+                "fields": [
+                  {
+                    "name": "Branch",
+                    "value": "`${{ github.ref_name }}`",
+                    "inline": true
+                  },
+                  {
+                    "name": "Commits",
+                    "value": "${{ github.event.commits.length }}",
+                    "inline": true
+                  }
+                ],
+                "description": "```\n${{ github.event.head_commit.message }}\n```",
+                "footer": {
+                  "text": "By ${{ github.actor }} • ${{ github.event.head_commit.timestamp }}"
+                }
+              }],
+              "thread_id": "${{ env.DISCORD_THREAD_ID }}"
+            }
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+
+      - name: Error Notification
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: '⚠️ Discord notification failed. Check Actions logs for details.'
+              });
+            } catch (error) {
+              console.error('Failed to create error comment:', error);
+            }

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-  DISCORD_THREAD_ID: 1332133384075481098
+  DISCORD_THREAD_ID: "1332133384075481098"
   SKIP_KEYWORD: '[skip notification]'
 
 jobs:
@@ -53,6 +53,8 @@ jobs:
           !contains(github.event.pull_request.title, env.SKIP_KEYWORD) &&
           !github.event.pull_request.draft
         uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           args: |
             {
@@ -85,16 +87,16 @@ jobs:
                   "text": "By ${{ github.actor }} • ${{ github.event.pull_request.updated_at }}"
                 }
               }],
-              "thread_id": "${{ toJSON(env.DISCORD_THREAD_ID) }}"
+              "thread_id": "${{ env.DISCORD_THREAD_ID }}"
             }
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
       - name: Push Notification
         if: |
           github.event_name == 'push' &&
           !contains(github.event.head_commit.message, env.SKIP_KEYWORD)
         uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           args: |
             {
@@ -118,10 +120,8 @@ jobs:
                   "text": "By ${{ github.actor }} • ${{ github.event.head_commit.timestamp }}"
                 }
               }],
-              "thread_id": "${{ toJSON(env.DISCORD_THREAD_ID) }}"
+              "thread_id": "${{ env.DISCORD_THREAD_ID }}"
             }
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
       - name: Error Notification
         if: failure() && github.event_name == 'pull_request'

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -12,23 +12,15 @@ jobs:
       - name: Discord notification
         if: github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: "${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938"
         uses: Ilshidur/action-discord@master
         with:
-          args: >
-            {
-              "content": "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}",
-              "thread_id": "1330422313769893938"
-            }
+          args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
 
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: "${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938"
         uses: Ilshidur/action-discord@master
         with:
-          args: >
-            {
-              "content": "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}",
-              "thread_id": "1330422313769893938"
-            }
+          args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -1,140 +1,38 @@
-name: Enhanced Discord Notifications
+name: PR Discord Notification
 
 on:
-  pull_request:
-    types: [opened, reopened, closed, ready_for_review, synchronize]
-  push:
-    branches: [main, develop]
-    tags: ['v*']
   workflow_dispatch:
-
-env:
-  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-  DISCORD_THREAD_ID: "1332133384075481098"
-  SKIP_KEYWORD: '[skip notification]'
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
 
 jobs:
   notify:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
-    concurrency:
-      group: notify-${{ github.event_name }}-${{ github.ref }}
-      cancel-in-progress: true
-
     steps:
-      - name: Prepare PR Metadata
-        id: prepare
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number
-              });
-              return {
-                changed_files: pr.changed_files,
-                additions: pr.additions,
-                deletions: pr.deletions,
-                labels: pr.labels.map(label => label.name).join(', ') || 'None',
-                branch: pr.head.ref,
-                base: pr.base.ref
-              };
-            } catch (error) {
-              core.setFailed(`Failed to get PR data: ${error.message}`);
-              return {};
-            }
+      - uses: actions/checkout@v2
 
-      - name: PR Notification
-        if: |
-          github.event_name == 'pull_request' &&
-          !contains(github.event.pull_request.title, env.SKIP_KEYWORD) &&
-          !github.event.pull_request.draft
-        uses: Ilshidur/action-discord@master
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Create PR notification
+        if: github.event.pull_request.draft == false
+        uses: tsickert/discord-webhook@v6.0.0
         with:
-          args: |
-            {
-              "embeds": [{
-                "title": "${{ github.event.pull_request.merged && '🚀 Merged PR' || '🔄 Updated PR' }}",
-                "color": ${{ github.event.pull_request.merged && '32768' || '5814783' }},
-                "fields": [
-                  {
-                    "name": "Title",
-                    "value": "[${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})",
-                    "inline": false
-                  },
-                  {
-                    "name": "Branch",
-                    "value": "`${{ fromJSON(steps.prepare.outputs.result).branch }} ➜ ${{ fromJSON(steps.prepare.outputs.result).base }}`",
-                    "inline": true
-                  },
-                  {
-                    "name": "Changes",
-                    "value": "📄 ${{ fromJSON(steps.prepare.outputs.result).changed_files }} files (+${{ fromJSON(steps.prepare.outputs.result).additions }}/-${{ fromJSON(steps.prepare.outputs.result).deletions }})",
-                    "inline": true
-                  },
-                  {
-                    "name": "Labels",
-                    "value": "${{ fromJSON(steps.prepare.outputs.result).labels }}",
-                    "inline": true
-                  }
-                ],
-                "footer": {
-                  "text": "By ${{ github.actor }} • ${{ github.event.pull_request.updated_at }}"
-                }
-              }],
-              "thread_id": "${{ env.DISCORD_THREAD_ID }}"
-            }
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          thread-id: "1330422313769893938"
+          username: "PR Bot"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          content: |
+            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+            **Title:** ${{ github.event.pull_request.title }}
+            **Author:** ${{ github.event.pull_request.user.login }}
 
-      - name: Push Notification
-        if: |
-          github.event_name == 'push' &&
-          !contains(github.event.head_commit.message, env.SKIP_KEYWORD)
-        uses: Ilshidur/action-discord@master
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Create PR merged notification
+        if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
+        uses: tsickert/discord-webhook@v6.0.0
         with:
-          args: |
-            {
-              "embeds": [{
-                "title": "📦 ${{ contains(github.ref, 'main') && 'Production' || 'Development' }} Update",
-                "color": ${{ contains(github.ref, 'main') && '16711680' || '32768' }},
-                "fields": [
-                  {
-                    "name": "Branch",
-                    "value": "`${{ github.ref_name }}`",
-                    "inline": true
-                  },
-                  {
-                    "name": "Commits",
-                    "value": "${{ github.event.commits.length }}",
-                    "inline": true
-                  }
-                ],
-                "description": "```\n${{ github.event.head_commit.message }}\n```",
-                "footer": {
-                  "text": "By ${{ github.actor }} • ${{ github.event.head_commit.timestamp }}"
-                }
-              }],
-              "thread_id": "${{ env.DISCORD_THREAD_ID }}"
-            }
-
-      - name: Error Notification
-        if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: '⚠️ Discord notification failed. Check Actions logs for details.'
-              });
-            } catch (error) {
-              console.error('Failed to create error comment:', error);
-            }
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          thread-id: "1330422313769893938"
+          username: "PR Bot"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          content: |
+            🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+            **Title:** ${{ github.event.pull_request.title }}
+            **Merged by:** ${{ github.event.pull_request.merged_by.login }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -85,7 +85,7 @@ jobs:
                   "text": "By ${{ github.actor }} • ${{ github.event.pull_request.updated_at }}"
                 }
               }],
-              "thread_id": "${{ env.DISCORD_THREAD_ID }}"
+              "thread_id": "${{ toJSON(env.DISCORD_THREAD_ID) }}"
             }
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
@@ -118,7 +118,7 @@ jobs:
                   "text": "By ${{ github.actor }} • ${{ github.event.head_commit.timestamp }}"
                 }
               }],
-              "thread_id": "${{ env.DISCORD_THREAD_ID }}"
+              "thread_id": "${{ toJSON(env.DISCORD_THREAD_ID) }}"
             }
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -15,23 +15,22 @@ jobs:
         if: github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           username: "FrontPR Bot"
-          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
-            ${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}
-            **标题:** ${{ github.event.pull_request.title }}
-            **作者:** ${{ github.event.pull_request.user.login }}
+            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Update:' }} ${{ github.event.pull_request.html_url }}
+            **Title:** ${{ github.event.pull_request.title }}
+            **Author:** ${{ github.event.pull_request.user.login }}
 
       - name: Create PR merged notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           username: "Front PR Bot"
           content: |
-            🎉 PR已合并: ${{ github.event.pull_request.html_url }}
-            **标题:** ${{ github.event.pull_request.title }}
-            **合并者:** ${{ github.event.pull_request.merged_by.login }}
+            🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+            **Title:** ${{ github.event.pull_request.title }}
+            **Author:** ${{ github.event.pull_request.merged_by.login }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -12,25 +12,15 @@ jobs:
       - name: Discord notification
         if: github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
-          THREAD_ID: "1330422313769893938"
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
-          args: |
-            {
-              "content": "${{ github.event.action == 'opened' && '🆕 新PR :' || '🔄 PR更新 :' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}",
-              "thread_id": "1330422313769893938"
-            }
+          args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
 
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
-          THREAD_ID: "1330422313769893938"
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
-          args: |
-            {
-              "content": "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}",
-              "thread_id": "1330422313769893938"
-            }
+          args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           args: |
             {
-              "content": "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}",
+              "content": "${{ github.event.action == 'opened' && '🆕 新PR :' || '🔄 PR更新 :' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}",
               "thread_id": "1330422313769893938"
             }
 

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -12,15 +12,25 @@ jobs:
       - name: Discord notification
         if: github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}&thread_id=1330422313769893938
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
+          THREAD_ID: "1330422313769893938"
         uses: Ilshidur/action-discord@master
         with:
-          args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
+          args: |
+            {
+              "content": "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}",
+              "thread_id": "1330422313769893938"
+            }
 
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}&thread_id=1330422313769893938
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
+          THREAD_ID: "1330422313769893938"
         uses: Ilshidur/action-discord@master
         with:
-          args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"
+          args: |
+            {
+              "content": "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}",
+              "thread_id": "1330422313769893938"
+            }

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Discord notification
         if: github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
         uses: Ilshidur/action-discord@master
         with:
           args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
@@ -20,7 +20,7 @@ jobs:
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
         uses: Ilshidur/action-discord@master
         with:
           args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          username: "FrontPR Bot"
+          username: "Front PR Bot"
           avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -9,18 +9,29 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Discord notification
-        if: github.event.pull_request.draft == false
-        env:
-          DISCORD_WEBHOOK: "${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938"
-        uses: Ilshidur/action-discord@master
-        with:
-          args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
+      - uses: actions/checkout@v2
 
-      - name: Discord merge notification
-        if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        env:
-          DISCORD_WEBHOOK: "${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938"
-        uses: Ilshidur/action-discord@master
+      - name: Create PR notification
+        if: github.event.pull_request.draft == false
+        uses: tsickert/discord-webhook@v6.0.0
         with:
-          args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"
+          webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
+          thread-id: "1330422313769893938"
+          username: "FrontPR Bot"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          content: |
+            ${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}
+            **标题:** ${{ github.event.pull_request.title }}
+            **作者:** ${{ github.event.pull_request.user.login }}
+
+      - name: Create PR merged notification
+        if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
+          thread-id: "1330422313769893938"
+          username: "Front PR Bot"
+          content: |
+            🎉 PR已合并: ${{ github.event.pull_request.html_url }}
+            **标题:** ${{ github.event.pull_request.title }}
+            **合并者:** ${{ github.event.pull_request.merged_by.login }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Discord notification
         if: github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}&thread_id=1330422313769893938
         uses: Ilshidur/action-discord@master
         with:
           args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
@@ -20,7 +20,7 @@ jobs:
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}&thread_id=1330422313769893938
         uses: Ilshidur/action-discord@master
         with:
           args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -16,9 +16,10 @@ jobs:
         uses: Ilshidur/action-discord@master
         with:
           args: |
-            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
-            **Title:** ${{ github.event.pull_request.title }}
-            **Author:** ${{ github.event.pull_request.user.login }}
+            {
+              "content": "${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}\n**Title:** ${{ github.event.pull_request.title }}\n**Author:** ${{ github.event.pull_request.user.login }}",
+              "thread_id": "1330422313769893938"
+            }
 
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
@@ -27,6 +28,7 @@ jobs:
         uses: Ilshidur/action-discord@master
         with:
           args: |
-            🎉 PR Merged: ${{ github.event.pull_request.html_url }}
-            **Title:** ${{ github.event.pull_request.title }}
-            **Merged by:** ${{ github.event.pull_request.merged_by.login }}
+            {
+              "content": "🎉 PR Merged: ${{ github.event.pull_request.html_url }}\n**Title:** ${{ github.event.pull_request.title }}\n**Merged by:** ${{ github.event.pull_request.merged_by.login }}",
+              "thread_id": "1330422313769893938"
+            }

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -15,8 +15,8 @@ jobs:
         if: github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
-          webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
-          thread-id: 1330422313769893938
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          thread-id: "1330422313769893938"
           username: "FrontPR Bot"
           avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
@@ -28,10 +28,9 @@ jobs:
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
-          webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
-          thread-id: 1330422313769893938
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          thread-id: "1330422313769893938"
           username: "Front PR Bot"
-          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
             🎉 PR已合并: ${{ github.event.pull_request.html_url }}
             **标题:** ${{ github.event.pull_request.title }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -22,7 +22,7 @@ jobs:
           content: |
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
-            **Author:** ${{ github.event.pull_request.user.login }}
+            <@&1315850473391001674>
 
       - name: Create PR merged notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
@@ -35,4 +35,4 @@ jobs:
           content: |
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
-            **Author:** ${{ github.event.pull_request.merged_by.login }}
+            <@&1315850473391001674>

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -9,30 +9,24 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Create PR notification
+      - name: Discord notification
         if: github.event.pull_request.draft == false
-        uses: tsickert/discord-webhook@v6.0.0
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@master
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
-          thread-id: "1330422313769893938"
-          username: "PR Bot"
-          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-          content: |
+          args: |
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
             **Author:** ${{ github.event.pull_request.user.login }}
 
-      - name: Create PR merged notification
+      - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        uses: tsickert/discord-webhook@v6.0.0
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@master
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
-          thread-id: "1330422313769893938"
-          username: "PR Bot"
-          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-          content: |
+          args: |
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
             **Merged by:** ${{ github.event.pull_request.merged_by.login }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -18,8 +18,9 @@ jobs:
           webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           username: "FrontPR Bot"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
-            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Update:' }} ${{ github.event.pull_request.html_url }}
+            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
             **Author:** ${{ github.event.pull_request.user.login }}
 
@@ -30,6 +31,7 @@ jobs:
           webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           username: "Front PR Bot"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -16,7 +16,7 @@ jobs:
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
-          thread-id: "1330422313769893938"
+          thread-id: 1330422313769893938
           username: "FrontPR Bot"
           avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
@@ -29,8 +29,9 @@ jobs:
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
-          thread-id: "1330422313769893938"
+          thread-id: 1330422313769893938
           username: "Front PR Bot"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
             🎉 PR已合并: ${{ github.event.pull_request.html_url }}
             **标题:** ${{ github.event.pull_request.title }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -12,23 +12,15 @@ jobs:
       - name: Discord notification
         if: github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: "https://discord.com/api/webhooks/xF1Ctgaci6HeOYjGnRYOmHLBRLWPn1WAXMtKe5c7bfC4r9MKssyE1rJZMZ_vuuMg92_Y"
+          DISCORD_WEBHOOK: "https://discord.com/api/webhooks/1332133384075481098/xF1Ctgaci6HeOYjGnRYOmHLBRLWPn1WAXMtKe5c7bfC4r9MKssyE1rJZMZ_vuuMg92_Y"
         uses: Ilshidur/action-discord@master
         with:
-          args: |
-            {
-              "content": "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}",
-              "thread_id": "1330422313769893938"
-            }
+          args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
 
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: "https://discord.com/api/webhooks/xF1Ctgaci6HeOYjGnRYOmHLBRLWPn1WAXMtKe5c7bfC4r9MKssyE1rJZMZ_vuuMg92_Y"
+          DISCORD_WEBHOOK: "https://discord.com/api/webhooks/1332133384075481098/xF1Ctgaci6HeOYjGnRYOmHLBRLWPn1WAXMtKe5c7bfC4r9MKssyE1rJZMZ_vuuMg92_Y"
         uses: Ilshidur/action-discord@master
         with:
-          args: |
-            {
-              "content": "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}",
-              "thread_id": "1330422313769893938"
-            }
+          args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Discord notification
         if: github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: "https://discord.com/api/webhooks/1332133384075481098/xF1Ctgaci6HeOYjGnRYOmHLBRLWPn1WAXMtKe5c7bfC4r9MKssyE1rJZMZ_vuuMg92_Y"
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
           args: "${{ github.event.action == 'opened' && '🆕 新PR:' || '🔄 PR更新:' }} ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**作者:** ${{ github.event.pull_request.user.login }}"
@@ -20,7 +20,7 @@ jobs:
       - name: Discord merge notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         env:
-          DISCORD_WEBHOOK: "https://discord.com/api/webhooks/1332133384075481098/xF1Ctgaci6HeOYjGnRYOmHLBRLWPn1WAXMtKe5c7bfC4r9MKssyE1rJZMZ_vuuMg92_Y"
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
           args: "🎉 PR已合并: ${{ github.event.pull_request.html_url }}\n**标题:** ${{ github.event.pull_request.title }}\n**合并者:** ${{ github.event.pull_request.merged_by.login }}"


### PR DESCRIPTION
<!-- discord_notifications.md -->

# Enhanced Discord Notifications Workflow for PR Activities

## Story
As a developer, I would like to see the latest PR in our daily communication channel, such that I can get notified and review the PR at my first convenience.

## Key Changes
- **Added GitHub Actions workflow** for Discord notifications.
- **Configured notifications** for PR events (opened, reopened, synchronized, closed).
- **Implemented Chinese language notifications** for better readability.
- **Set up secure webhook handling** using GitHub secrets.
- **Added separate notifications** for PR updates and merges.
- **Customized notification format** with emojis and markdown formatting.

## Test Method
- Created a test PR to verify notification delivery.
- Tested different PR events (open, update, merge).
- Verified notifications appear in the correct Discord channel.
- Confirmed that Chinese text displays properly.
- Validated secure webhook configuration.

## Related Ticket
*Please replace with the actual ticket link.*


[JIRA Ticket: IF-185](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-Num)
